### PR TITLE
Change exportmodes to enum.Flag

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,4 +1,3 @@
-name: pdfarranger-mh
 on:
   push:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,117 +1,27 @@
 ## About
 
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/pdfarranger/pdfarranger.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pdfarranger/pdfarranger/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/pdfarranger/pdfarranger.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pdfarranger/pdfarranger/context:python)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/1be9c9a69f3a44b79612cc5b2887c0f7)](https://www.codacy.com/gh/pdfarranger/pdfarranger/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pdfarranger/pdfarranger&amp;utm_campaign=Badge_Grade)
-[![pdfarranger](https://github.com/pdfarranger/pdfarranger/workflows/pdfarranger/badge.svg)](https://github.com/pdfarranger/pdfarranger/actions?query=workflow%3Apdfarranger+branch%3Amain)
-[![codecov](https://codecov.io/gh/pdfarranger/pdfarranger/branch/main/graph/badge.svg)](https://codecov.io/gh/pdfarranger/pdfarranger)
-
-*PDF Arranger* is a small python-gtk application, which helps the user to merge
+This is the development branch of my fork of the official [PDF Arranger](https://github.com/pdfarranger/pdfarranger)
+*pdfarranger* is a small python-gtk application, which helps the user to merge
 or split pdf documents and rotate, crop and rearrange their pages using an
 interactive and intuitive graphical interface. It is a frontend for
 [pikepdf](https://github.com/pikepdf/pikepdf).
 
-*PDF Arranger* is a fork of Konstantinos Poulios’s pdfshuffler
-(see [Savannah](https://savannah.nongnu.org/projects/pdfshuffler) or
-[Sourceforge](http://sourceforge.net/projects/pdfshuffler)).
-It’s a humble attempt to make the project a bit more active.
+*pdfarranger* is a fork of Konstantinos Poulios’s pdfshuffler
 
-![screenshot of pdfarranger](https://github.com/pdfarranger/pdfarranger/raw/main/data/screenshot.png)
 
-## Downloads
 
-| [Microsoft® Windows®](https://github.com/pdfarranger/pdfarranger/releases) | <a href='https://flathub.org/apps/details/com.github.jeromerobert.pdfarranger'><img width='120' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.svg'/></a> | [More…](https://github.com/pdfarranger/pdfarranger/wiki/Binary-packages) |
-| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+### Changelog
 
-### Linux packages
 
-[![Linux packages](https://repology.org/badge/vertical-allrepos/pdfarranger.svg?columns=4)](https://repology.org/project/pdfarranger/versions)
 
-## Customization of keyboard shortcuts
 
-In case you are not satisfied with the default keyboard shortcuts they can be
-changed. To do so, set `enable_custom` to `true` in
-`~/.config/pdfarranger/config.ini` or
-`C:\Users\username\AppData\Roaming\pdfarranger\config.ini` and edit other
-lines.
 
-## Install from source
+- Change requirements to latest versions of requirements
+    pikepdf>=2.12, python-dateutil>=2.8.1, img2pdf>=0.4.1
 
-*PDF Arranger* requires [pikepdf](https://github.com/pikepdf/pikepdf) >= 1.17.0.
-pip will automatically install the latest pikepdf if there is no pikepdf installed on the system.
+    (This change does not affect the tests on Github)
+    Note pikepdf 2.10.0 fixes a security vulnerability
 
-**On Debian based distributions**
+- Change .github/workflows/install.yml
 
-```
-sudo apt-get install python3-pip python3-distutils-extra python3-wheel python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-poppler-0.18 python3-setuptools
-```
-
-**On Arch Linux**
-
-```
-sudo pacman -S poppler-glib python-distutils-extra python-pip python-gobject gtk3 python-cairo
-```
-
-**On Fedora**
-
-```
-sudo dnf install poppler-glib python3-distutils-extra python3-pip python3-gobject gtk3 python3-cairo python3-wheel python3-pikepdf python3-img2pdf python3-dateutil
-```
-
-**On FreeBSD**
-
-```
-sudo pkg install devel/gettext devel/py-gobject3 devel/py-pip devel/py-python-distutils-extra graphics/poppler-glib textproc/intltool textproc/py-pikepdf x11-toolkits/gtk30
-```
-
-**Then**
-
-```
-pip3 install --user --upgrade https://github.com/pdfarranger/pdfarranger/zipball/main
-```
-
-In addition, *PDF Arranger* supports image file import if [img2pdf](https://gitlab.mister-muffin.de/josch/img2pdf) is installed.
-
-## For developers
-
-```
-git clone https://github.com/pdfarranger/pdfarranger.git
-cd pdfarranger
-./setup.py build
-python3 -m pdfarranger
-```
-
-For Windows see [Win32.md](Win32.md).
-
-## For translators
-
--   Download the main branch (see [For developers](#for-developers))
-
--   Run `po/genpot.sh`. The `pot` is an automatically generated file and as such
-    should not be in the repository. It is to make life of some translators
-    easier, but it may be often not synchronized with the source code. If you can
-    regenerate it before adding or updating a translation, then do it.
-
--   Translations are in the following files:
-    -   [`po`](po)`/*.po`
-    -   [data/com.github.jeromerobert.pdfarranger.metainfo.xml](data/com.github.jeromerobert.pdfarranger.metainfo.xml)
-    -   [data/com.github.jeromerobert.pdfarranger.desktop](data/com.github.jeromerobert.pdfarranger.desktop)
-
--   For mnemonics accelerators (letters preceded by an underscore) try to follow
-    those rules by priority order:
-    -   be consistent with other GTK/GNOME software
-    -   pick a unique letter **within that given menu** if possible
-    -   pick the same letter as the original string if available
-    -   pick a strong letter (e.g. in "Search and replace" rather pick `s`, `r` or `p` than `a`)
-
--   If possible test your translation to see it in context (see [For developers](#for-developers))
-
--   You may test different languages with `LANG=xx_YY python3 -m pdfarranger`
-
--   Do not include `pdfarranger.pot` (or any `*.po` file which was just
-    automatically regenerated) in your pull request. Submit only the translations
-    you actually updated or added.
-
--   If you don’t want or can’t use the developers tooling (`git`,
-    `po/genpot.sh`, `python`, …) you can edit, download or upload the `*.po`
-    files from the GitHub web pages.
+- rebased

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -131,13 +131,7 @@ def check_content(parent, pdf_list):
     return Gtk.ResponseType.OK, True
 
 
-def export(input_files, pages, file_out, mode, mdata):
-    exportmodes = {0: 'ALL_TO_SINGLE',
-                   1: 'ALL_TO_MULTIPLE',
-                   2: 'SELECTED_TO_SINGLE',
-                   3: 'SELECTED_TO_MULTIPLE'}
-    exportmode = exportmodes[mode.get_int32()]
-
+def export(input_files, pages, file_out, to_multiple, mdata):
     global _report_pikepdf_err
     pdf_output = pikepdf.Pdf.new()
     pdf_input = [pikepdf.open(p.copyname, password=p.password) for p in input_files]
@@ -163,7 +157,7 @@ def export(input_files, pages, file_out, mode, mdata):
             pdf_temp.pages.append(current_page)
             pdf_output.pages[-1].Annots = pdf_output.copy_foreign(pdf_temp.pages[0].Annots)
 
-    if exportmode in ['ALL_TO_MULTIPLE', 'SELECTED_TO_MULTIPLE']:
+    if to_multiple:
         for n, page in enumerate(pdf_output.pages):
             outpdf = pikepdf.Pdf.new()
             _set_meta(mdata, pdf_input, outpdf)

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+import os
 from setuptools import setup
 from DistUtilsExtra.command import (
     build_i18n, clean_i18n, build_extra, build_icons)
+
+gh_workflow = os.environ.get('GH', None)
+
 
 data_files = [
     ('share/applications', ['data/com.github.jeromerobert.pdfarranger.desktop']),
@@ -51,8 +54,14 @@ setup(
     entry_points={
         'console_scripts': ['pdfarranger=pdfarranger.pdfarranger:main']
     },
-    install_requires=['pikepdf>=1.17.0','python-dateutil>=2.4.0'],
-    extras_require={
-        'image': ['img2pdf>=0.3.4'],
-    },
+    if gh_workflow is None:
+        install_requires=['pikepdf>=2.12.0','python-dateutil>=2.8.1'],
+        extras_require={
+            'image': ['img2pdf>=0.4.1'],
+        },
+    else:
+        install_requires=['pikepdf>=1.7.0','python-dateutil>=2.4.0'],
+        extras_require={
+            'image': ['img2pdf>=0.3.4'],
+        },
 )


### PR DESCRIPTION
- change exportmodes to enum.Flag
- move write action handlers and related method to be in a single block
- rename choose_export_selection_pdf_name to be consistent with other
  action handlers
- replace export and save in various variable identifiers with write to
  reflect that the code handles both saving and exporting