### PR TITLE
Change exportmodes to enum.Flag

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,7 +1,6 @@
-name: pdfarranger
+name: pdfarranger-mh-dev
 on:
   push:
-    branches: [ main ]
   pull_request:
 jobs:
   build:
@@ -10,40 +9,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install
-      run: pip3 install .[image]
+      run: GH=1 pip3 install .[image]
     - name: AppStream
       run: appstreamcli validate /usr/share/metainfo/com.github.jeromerobert.pdfarranger.metainfo.xml
     - name: Validate Desktop File
       run: desktop-file-validate /usr/share/applications/com.github.jeromerobert.pdfarranger.desktop
     - name: Tests and Coverage
       run: python3 -X tracemalloc -u -m unittest discover -v -f -s tests
-    - name: Codecov
-      run: curl -s https://codecov.io/bash | bash
-  build-win32:
-    runs-on: ubuntu-latest
-    container:
-      image: jeromerobert/wine-mingw64
-      options: --user root
-    steps:
-    - uses: actions/checkout@v2
-    - run: ./setup.py build
-    - run: HOME=/root wine python setup_win32.py bdist_msi
-    - run: HOME=/root wine python setup_win32.py bdist_zip
-    - uses: actions/upload-artifact@v2
-      with:
-        name: pdfarranger-windows-installer-msi
-        path: dist/*.msi
-    - uses: actions/upload-artifact@v2
-      with:
-        name: pdfarranger-windows-portable-zip
-        path: dist/*.zip
-  rpmbuild:
-    runs-on: ubuntu-latest
-    container: dreua/pdfarranger-docker-rpm
-    steps:
-    - name: RPM Build
-      run: /pdfarranger/pdfarranger-build
-    - uses: actions/upload-artifact@v2
-      with:
-        name: pdfarranger-fedora-testbuild
-        path: /github/home/rpmbuild/**/*.rpm
+

--- a/pdfarranger/const.py
+++ b/pdfarranger/const.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2021 Manfred Holger
+#
+# pdfarranger is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+'''
+Constants and enumerations for PDF Arranger
+'''
+
+import enum
+
+
+class WriteMode(enum.Flag):
+    SAVE = 0
+    TO_MULTIPLE = 1
+    SELECTION = 2
+    EXPORT = 3
+    SAVE_AS = 4

--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -131,13 +131,7 @@ def check_content(parent, pdf_list):
     return Gtk.ResponseType.OK, True
 
 
-def export(input_files, pages, file_out, mode, mdata):
-    exportmodes = {0: 'ALL_TO_SINGLE',
-                   1: 'ALL_TO_MULTIPLE',
-                   2: 'SELECTED_TO_SINGLE',
-                   3: 'SELECTED_TO_MULTIPLE'}
-    exportmode = exportmodes[mode.get_int32()]
-
+def export(input_files, pages, file_out, to_multiple, mdata):
     global _report_pikepdf_err
     pdf_output = pikepdf.Pdf.new()
     pdf_input = [pikepdf.open(p.copyname, password=p.password) for p in input_files]
@@ -163,7 +157,7 @@ def export(input_files, pages, file_out, mode, mdata):
             pdf_temp.pages.append(current_page)
             pdf_output.pages[-1].Annots = pdf_output.copy_foreign(pdf_temp.pages[0].Annots)
 
-    if exportmode in ['ALL_TO_MULTIPLE', 'SELECTED_TO_MULTIPLE']:
+    if to_multiple:
         for n, page in enumerate(pdf_output.pages):
             outpdf = pikepdf.Pdf.new()
             _set_meta(mdata, pdf_input, outpdf)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -110,6 +110,7 @@ from . import exporter
 from . import metadata
 from . import croputils
 from . import splitter
+from .const import WriteMode
 from .iconview import CellRendererImage
 from .iconview import IconviewCursor
 from .iconview import IconviewDragSelect
@@ -309,7 +310,7 @@ class PdfArranger(Gtk.Application):
             ('duplicate', self.duplicate),
             ('page-format', self.page_format_dialog),
             ('crop-white-borders', self.crop_white_borders),
-            ('export-selection', self.choose_export_selection_pdf_name, 'i'),
+            ('export-selection', self.on_action_export_selection, 'i'),
             ('export-all', self.on_action_export_all),
             ('reverse-order', self.reverse_order),
             ('save', self.on_action_save),
@@ -582,15 +583,6 @@ class PdfArranger(Gtk.Application):
         if len(self.model) > 1: # Don't trigger extra render after first page is inserted
             self.silent_render()
 
-    def set_export_file(self, file):
-        if file != self.export_file:
-            self.export_file = file
-            self.set_unsaved(True)
-
-    def set_unsaved(self, flag):
-        self.is_unsaved = flag
-        GObject.idle_add(self.retitle)
-
     def retitle(self):
         if self.export_file:
             title = self.export_file
@@ -775,7 +767,85 @@ class PdfArranger(Gtk.Application):
             shutil.rmtree(self.tmp_dir)
         self.quit()
 
-    def choose_export_pdf_name(self, mode):
+    def active_file_names(self):
+        """Returns the file names currently associated with pages in the model."""
+        r = set(row[1].split('\n')[0] for row in self.model)
+        r.discard("")
+        return r
+
+    def on_action_new(self, _action, _param, _unknown):
+        """Start a new instance."""
+        if os.name == 'nt':
+            if sys.executable.find('python3.exe') == -1:
+                subprocess.Popen(sys.executable)
+            else:
+                subprocess.Popen([sys.executable, '-mpdfarranger'])
+        else:
+            display = Gdk.Display.get_default()
+            launch_context = display.get_app_launch_context()
+            desktop_file = "%s.desktop"%(self.get_application_id())
+            try:
+                app_info = Gio.DesktopAppInfo.new(desktop_file)
+                app_info.launch([], launch_context)
+            except TypeError:
+                subprocess.Popen([sys.executable, '-mpdfarranger'])
+
+    #
+    # Write actions and related methods
+    #
+
+    def on_action_save(self, _action, _param, _unknown):
+        self.save_or_choose()
+
+    def on_action_save_as(self, _action, _param, _unknown):
+        self.choose_export_pdf_name(WriteMode.SAVE)
+
+    def on_action_export_selection(self, _action, writemode, _unknown):
+        self.choose_export_pdf_name(WriteMode(writemode.get_int32()))
+
+    def on_action_export_all(self, _action, _param, _unknown):
+        self.choose_export_pdf_name(WriteMode.TO_MULTIPLE)
+
+    def save_or_choose(self):
+        """Saves to the previously exported file or shows the export dialog if
+        there was none."""
+        writemode = WriteMode.SAVE
+        try:
+            if self.export_file:
+                self.save(writemode, self.export_file)
+            else:
+                self.choose_export_pdf_name(writemode)
+        except Exception as e:
+            self.error_message_dialog(e)
+
+    @warn_dialog
+    def save(self, writemode, file_out):
+        """Saves to the specified file.  May throw exceptions."""
+        (path, shortname) = os.path.split(file_out)
+        (shortname, ext) = os.path.splitext(shortname)
+        if ext.lower() != '.pdf':
+            file_out = file_out + '.pdf'
+
+        if writemode & WriteMode.SELECTION:
+            selection = self.iconview.get_selected_items()
+            to_export = [row[0] for row in self.model if row.path in selection]
+        else:
+            self.export_directory = path
+            self.set_export_file(file_out)
+            to_export = [row[0] for row in self.model]
+
+        m = metadata.merge(self.metadata, self.pdfqueue)
+        if self.config.content_loss_warning():
+            res, enabled = exporter.check_content(self.window, self.pdfqueue)
+            self.config.set_content_loss_warning(enabled)
+            if res == Gtk.ResponseType.CANCEL:
+                return # Abort
+        exporter.export(self.pdfqueue, to_export, file_out, writemode & WriteMode.TO_MULTIPLE, m)
+
+        if writemode | WriteMode.SAVE_AS == WriteMode.SAVE_AS: # i.e. SAVE or SAVE_AS
+            self.set_unsaved(False)
+
+    def choose_export_pdf_name(self, writemode):
         """Handles choosing a name for exporting """
 
         chooser = Gtk.FileChooserDialog(title=_('Export…'),
@@ -801,90 +871,19 @@ class PdfArranger(Gtk.Application):
         chooser.destroy()
         if response == Gtk.ResponseType.ACCEPT:
             try:
-                self.save(mode, file_out)
+                self.save(writemode, file_out)
             except Exception as e:
                 traceback.print_exc()
                 self.error_message_dialog(e)
 
-    def active_file_names(self):
-        """Returns the file names currently associated with pages in the model."""
-        r = set(row[1].split('\n')[0] for row in self.model)
-        r.discard("")
-        return r
+    def set_export_file(self, file):
+        if file != self.export_file:
+            self.export_file = file
+            self.set_unsaved(True)
 
-    def on_action_new(self, _action, _param, _unknown):
-        """Start a new instance."""
-        if os.name == 'nt':
-            if sys.executable.find('python3.exe') == -1:
-                subprocess.Popen(sys.executable)
-            else:
-                subprocess.Popen([sys.executable, '-mpdfarranger'])
-        else:
-            display = Gdk.Display.get_default()
-            launch_context = display.get_app_launch_context()
-            desktop_file = "%s.desktop"%(self.get_application_id())
-            try:
-                app_info = Gio.DesktopAppInfo.new(desktop_file)
-                app_info.launch([], launch_context)
-            except TypeError:
-                subprocess.Popen([sys.executable, '-mpdfarranger'])
-
-    def on_action_save(self, _action, _param, _unknown):
-        self.save_or_choose()
-
-    def save_or_choose(self):
-        """Saves to the previously exported file or shows the export dialog if
-        there was none."""
-        savemode = GLib.Variant('i', 0) # Save all pages in a single document.
-        try:
-            if self.export_file:
-                self.save(savemode, self.export_file)
-            else:
-                self.choose_export_pdf_name(savemode)
-        except Exception as e:
-            self.error_message_dialog(e)
-
-    def on_action_save_as(self, _action, _param, _unknown):
-        self.choose_export_pdf_name(GLib.Variant('i', 0))
-
-    @warn_dialog
-    def save(self, mode, file_out):
-        """Saves to the specified file.  May throw exceptions."""
-        (path, shortname) = os.path.split(file_out)
-        (shortname, ext) = os.path.splitext(shortname)
-        if ext.lower() != '.pdf':
-            file_out = file_out + '.pdf'
-
-        exportmodes = {0: 'ALL_TO_SINGLE',
-                       1: 'ALL_TO_MULTIPLE',
-                       2: 'SELECTED_TO_SINGLE',
-                       3: 'SELECTED_TO_MULTIPLE'}
-        exportmode = exportmodes[mode.get_int32()]
-
-        if exportmode in ['SELECTED_TO_SINGLE', 'SELECTED_TO_MULTIPLE']:
-            selection = self.iconview.get_selected_items()
-            to_export = [row[0] for row in self.model if row.path in selection]
-        else:
-            self.export_directory = path
-            self.set_export_file(file_out)
-            to_export = [row[0] for row in self.model]
-
-        m = metadata.merge(self.metadata, self.pdfqueue)
-        if self.config.content_loss_warning():
-            res, enabled = exporter.check_content(self.window, self.pdfqueue)
-            self.config.set_content_loss_warning(enabled)
-            if res == Gtk.ResponseType.CANCEL:
-                return # Abort
-        exporter.export(self.pdfqueue, to_export, file_out, mode, m)
-
-        if exportmode == 'ALL_TO_SINGLE':
-            self.set_unsaved(False)
-
-    def choose_export_selection_pdf_name(self, _action, mode, _unknown):
-        self.choose_export_pdf_name(mode)
-
-    def on_action_export_all(self, _action, _param, _unknown):
-        self.choose_export_pdf_name(GLib.Variant('i', 1))
+    def set_unsaved(self, flag):
+        self.is_unsaved = flag
+        GObject.idle_add(self.retitle)
 
     def on_action_add_doc_activate(self, _action, _param, _unknown):
         """Import doc"""


### PR DESCRIPTION
- add module const for constants and enumerations
- change exportmodes to enum.Flag
- move write action handlers and related method to be in a single block
- rename choose_export_selection_pdf_name to be consistent with other
  action handlers
- replace export and save in various variable identifiers with write to
  reflect that the code handles both saving and exporting